### PR TITLE
added reverse function for pem => ssh-rsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ read a ssh key and convert it to PEM format.
 
     console.log(key)
 
+Alternatively, convert a PEM format public key into an `ssh-rsa` key
+
+    var fs = require('fs');
+    var pemToRsaSSHKey = require('ssh-key-to-pem').pemToRsaSSHKey;
+
+    var key = fs.readFileSync('./pub_key.pem', 'ascii')
+    var sshKey = pemToRsaSSHKey(key);
+
+    console.log(sshKey)
+
 ## Installation
 
     npm install ssh-key-to-pem

--- a/index.js
+++ b/index.js
@@ -213,6 +213,65 @@ function dsaToPEM(key) {
 module.exports = sshKeyToPEM
 sshKeyToPEM.sshKeyToPEM = sshKeyToPEM
 
+/**
+ * Converts a PKGCS#8 PEM file to an OpenSSH public key (rsa)
+ *
+ * The reverse of the above function.
+ */
+function pemToRsaSSHKey(pem, comment) {
+  assert.equal('string', typeof pem, 'typeof pem');
+
+  // chop off the BEGIN PUBLIC KEY and END PUBLIC KEY portion
+  var cleaned = pem.split('\n').slice(1, -2).join('');
+
+  var buf = new Buffer(cleaned, 'base64');
+
+  var der = new asn1.BerReader(buf);
+
+  der.readSequence();
+  der.readSequence();
+
+  var oid = der.readOID();
+  assert.equal(oid, '1.2.840.113549.1.1.1', 'pem not in RSA format');
+
+  // Null -- XXX this probably isn't good practice
+  der.readByte();
+  der.readByte();
+
+  // bit string sequence
+  der.readSequence(0x03);
+  der.readByte();
+  der.readSequence();
+
+  // modulus
+  assert.equal(der.peek(), asn1.Ber.Integer, 'modulus not an integer');
+  der._offset = der.readLength(der.offset + 1);
+  var modulus = der._buf.slice(der.offset, der.offset + der.length);
+  der._offset += der.length;
+
+  // exponent
+  assert.equal(der.peek(), asn1.Ber.Integer, 'exponent not an integer');
+  der._offset = der.readLength(der.offset + 1);
+  var exponent = der._buf.slice(der.offset, der.offset + der.length);
+  der._offset += der.length;
+
+  // now, make the key
+  var type = new Buffer('ssh-rsa');
+  var buffer = new Buffer(4 + type.length + 4 + modulus.length + 4 + exponent.length);
+  var i = 0;
+  buffer.writeUInt32BE(type.length, i);     i += 4;
+  type.copy(buffer, i);                     i += type.length;
+  buffer.writeUInt32BE(exponent.length, i); i += 4;
+  exponent.copy(buffer, i);                 i += exponent.length;
+  buffer.writeUInt32BE(modulus.length, i);  i += 4;
+  modulus.copy(buffer, i);                  i += modulus.length;
+
+  var s = type.toString() + ' ' + buffer.toString('base64') + ' ' + (comment || '');
+  return s;
+}
+
+sshKeyToPEM.pemToRsaSSHKey = pemToRsaSSHKey;
+
 
   /**
    * Generates an OpenSSH fingerprint from an ssh public key.

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -4,6 +4,7 @@ var test = require('tape');
 
 var sshKeyFingerprint = require('../').fingerprint;
 var sshKeyToPEM = require('../').sshKeyToPEM;
+var pemToRsaSSHKey = require('../').pemToRsaSSHKey;
 
 
 
@@ -85,11 +86,25 @@ var DSA_1024_PEM = '-----BEGIN PUBLIC KEY-----\n' +
 
 ///--- Tests
 
+test('1024b pem to rsa ssh key', function(t) {
+  t.equal(pemToRsaSSHKey(PEM_1024, 'mark@foo.local'), SSH_1024);
+  t.end();
+});
+
+test('2048b pem to rsa ssh key', function(t) {
+  t.equal(pemToRsaSSHKey(PEM_2048, 'mark@bluesnoop.local'), SSH_2048);
+  t.end();
+});
+
+test('4096b pem to rsa ssh key', function(t) {
+  t.equal(pemToRsaSSHKey(PEM_4096, 'mark@bluesnoop.local'), SSH_4096);
+  t.end();
+});
+
 test('1024b rsa ssh key', function(t) {
   t.equal(sshKeyToPEM(SSH_1024), PEM_1024);
   t.end();
 });
-
 
 test('2048b rsa ssh key', function(t) {
   t.equal(sshKeyToPEM(SSH_2048), PEM_2048);


### PR DESCRIPTION
# summary

this adds an exported function, `pemToRsaSSHKey` that takes a public key in PEM format, and returns an `ssh-rsa` key as a string.
# example

read in my public key to the node console

``` javascript
> var pubkey = fs.readFileSync('/Users/dave/.ssh/id_rsa.pub', 'utf-8')
> console.log(pubkey)
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+JUivj9iHGMnZ0eVS3hJ+jy6gHYLqwK5S6K6r/TaF0uuJv5mYEIIqhkEeg17XkYUZDW6Xcy0GdHNDI53DKTZhF4Ki3KnCQCfGYtLlNsQcvZ08WNTzXZDqXRvkIPwaGXppzuIohoI5J0Y1k89UrjfqBaY8n7JK+dAisA+OL/NXtdu6G+l3bQY28xEKTUkHSXpInQGRieS6veDReMlRg9hlpTWviGTx3SF4O0sD5SuggI+g4dYk311j8iR/AodGp0YxSWr694iBCiGJ5RtXbIaLPl2gdgSeKgonmTqdo3jVeMp7XljDxL+XPAf+Y5YbnhPUNd8P8Q8QElUfIwCJJ6hD dave@Operationss-MacBook-Pro.local
```

use this module to convert it to PEM format

``` js
> var sshkeymod = require('./')
> var pem = sshkeymod(pubkey)
> console.log(pem)
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAviVIr4/YhxjJ2dHlUt4S
fo8uoB2C6sCuUuiuq/02hdLrib+ZmBCCKoZBHoNe15GFGQ1ul3MtBnRzQyOdwyk2
YReCotypwkAnxmLS5TbEHL2dPFjU812Q6l0b5CD8Ghl6ac7iKIaCOSdGNZPPVK43
6gWmPJ+ySvnQIrAPji/zV7Xbuhvpd20GNvMRCk1JB0l6SJ0BkYnkur3g0XjJUYPY
ZaU1r4hk8d0heDtLA+UroICPoOHWJN9dY/IkfwKHRqdGMUlq+veIgQohieUbV2yG
iz5doHYEnioKJ5k6naN41XjKe15Yw8S/lzwH/mOWG54T1DXfD/EPEBJVHyMAiSeo
QwIDAQAB
-----END PUBLIC KEY-----
```

assert that the original pubkey (with trailing newline removed) is the same as `pemToRsaSSHKey(pem)` (full circle conversion)

``` js
> assert.strictEqual(sshkeymod.pemToRsaSSHKey(pem, 'dave@Operationss-MacBook-Pro.local'), pubkey.trim())
undefined
>
```
# tests

added test coverage for all 3 `ssh-rsa` keys found in the existing tests

```
dave @ [ bahamas10 :: (Darwin) ] ~/dev/ssh-key-to-pem (git:master) $ npm test

> ssh-key-to-pem@0.10.0 test /Users/dave/dev/ssh-key-to-pem
> node test/convert.test.js

TAP version 13
# 1024b pem to rsa ssh key
ok 1 should be equal
# 2048b pem to rsa ssh key
ok 2 should be equal
# 4096b pem to rsa ssh key
ok 3 should be equal
# 1024b rsa ssh key
ok 4 should be equal
# 2048b rsa ssh key
ok 5 should be equal
# 4096b rsa ssh key
ok 6 should be equal
# 1024b dsa ssh key
ok 7 should be equal
# fingerprint
ok 8 should be equal

1..8
# tests 8
# pass  8

# ok
```
