### PR TITLE
Change main value in package.json to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "node": ">=0.8"
   },
-  "main": "lib/index.js",
+  "main": "index.js",
   "scripts": {
     "test": "node test/convert.test.js"
   },


### PR DESCRIPTION
Was getting below error:

[DEP0128] DeprecationWarning: Invalid 'main' field in '/oauth-app/node_modules/ssh-key-to-pem/package.json' of 'lib/index.js'. Please either fix that or report it to the module author