### PR TITLE
Fix main script path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "node": ">=0.8"
   },
-  "main": "lib/index.js",
+  "main": "index.js",
   "scripts": {
     "test": "node test/convert.test.js"
   },


### PR DESCRIPTION
**Warning**

```
node:19748) [DEP0128] DeprecationWarning: Invalid 'main' field in '/app/node_modules/ssh-key-to-pem/package.json' of 'lib/index.js'. Please either fix that or report it to the module author (Use `node --trace-deprecation ...` to show where the warning was created)
```

**Fix**
Updated "main" field value to "index.js"

